### PR TITLE
Jenkins use multiconfig web page validation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,8 +149,9 @@ pipeline {
                 fi
                 export data_dir=/data/jenkins/workspace/validation_data
                 mkdir $data_dir/PR$CHANGE_ID
-                cp -rf GIFS/. $data_dir/PR$CHANGE_ID
-                python ../HGCTPGValidation/scripts/writeToFile.py --dirname $data_dir/PR$CHANGE_ID --prnumber $CHANGE_ID --prtitle "PR$CHANGE_ID : $CHANGE_TITLE (from $CHANGE_AUTHOR, $CHANGE_URL)"
+                mkdir $data_dir/PR$CHANGE_IDconfig1
+                cp -rf GIFS/. $data_dir/PR$CHANGE_IDconfig1
+                python ../HGCTPGValidation/scripts/writeToFile.py --dirname $data_dir/PR$CHANGE_ID --prnumber $CHANGE_ID --prtitle "$CHANGE_TITLE (from $CHANGE_AUTHOR, $CHANGE_URL)"
                 '''            
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,8 +149,8 @@ pipeline {
                 fi
                 export data_dir=/data/jenkins/workspace/validation_data
                 mkdir $data_dir/PR$CHANGE_ID
-                mkdir $data_dir/PR$CHANGE_IDconfig1
-                cp -rf GIFS/. $data_dir/PR$CHANGE_IDconfig1
+                mkdir $data_dir/PR$CHANGE_ID/PR$CHANGE_IDconfig1
+                cp -rf GIFS/. $data_dir/PR$CHANGE_ID/PR$CHANGE_IDconfig1
                 python ../HGCTPGValidation/scripts/writeToFile.py --dirname $data_dir/PR$CHANGE_ID --prnumber $CHANGE_ID --prtitle "$CHANGE_TITLE (from $CHANGE_AUTHOR, $CHANGE_URL)"
                 '''            
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,8 +149,8 @@ pipeline {
                 fi
                 export data_dir=/data/jenkins/workspace/validation_data
                 mkdir $data_dir/PR$CHANGE_ID
-                mkdir $data_dir/PR$CHANGE_ID/PR$CHANGE_IDconfig1
-                cp -rf GIFS/. $data_dir/PR$CHANGE_ID/PR$CHANGE_IDconfig1
+                mkdir $data_dir/PR$CHANGE_ID/"PR$CHANGE_ID"config1
+                cp -rf GIFS/. $data_dir/PR$CHANGE_ID/"PR$CHANGE_ID"config1
                 python ../HGCTPGValidation/scripts/writeToFile.py --dirname $data_dir/PR$CHANGE_ID --prnumber $CHANGE_ID --prtitle "$CHANGE_TITLE (from $CHANGE_AUTHOR, $CHANGE_URL)"
                 '''            
             }

--- a/scripts/writeToFile.py
+++ b/scripts/writeToFile.py
@@ -14,7 +14,7 @@ def writeIntoFile(prnumber, prtitle):
     with open('validation_webpages.txt', 'w') as f:
         prnb  = "PR" + prnumber
         title = prnb + " : " + prtitle + "\n"
-        title_config1 = prnb + "config1" + " : " + prtitle
+        title_config1 = "Config1"
         f.write(title + title_config1) 
 
 def main(dirname, prnumber, prtitle):

--- a/scripts/writeToFile.py
+++ b/scripts/writeToFile.py
@@ -14,7 +14,7 @@ def writeIntoFile(prnumber, prtitle):
     with open('validation_webpages.txt', 'w') as f:
         prnb  = "PR" + prnumber
         title = prnb + " : " + prtitle + "\n"
-        title_config1 = "Config1"
+        title_config1 = prnb + "config1" + " : Config1"
         f.write(title + title_config1) 
 
 def main(dirname, prnumber, prtitle):

--- a/scripts/writeToFile.py
+++ b/scripts/writeToFile.py
@@ -1,13 +1,22 @@
 # Write the PullRequest ($CHANGE_TITLE) name into a text file
-# python writeToFile.py --dirname PR$CHANGE_ID --prnumber $CHANGE_ID --prtitle "$CHANGE_TITLE"
+# python writeToFile.py --dirname PR$CHANGE_ID --prnumber $CHANGE_ID --prtitle "$CHANGE_TITLE (from $CHANGE_AUTHOR, $CHANGE_URL)"
+
+# File structure
+# PR$CHANGE_ID : $CHANGE_TITLE (from $CHANGE_AUTHOR, $CHANGE_URL)
+# PR$CHANGE_IDconfig1 : $CHANGE_TITLE (from $CHANGE_AUTHOR, $CHANGE_URL)
+# Ex : PR3 : Testing multiconfig (from user_name, https.....)
+#      PR3config1 : Testing multiconfig (from user_name, https.....)
 
 import os
 import sys
 
 def writeIntoFile(prnumber, prtitle):
     with open('validation_webpages.txt', 'w') as f:
-        f.write(prtitle)
-    
+        prnb  = "PR" + prnumber
+        title = prnb + " : " + prtitle + "\n"
+        title_config1 = prnb + "config1" + " : " + prtitle
+        f.write(title + title_config1) 
+
 def main(dirname, prnumber, prtitle):
     print('dirname = ', dirname)
     print('prtitle = ', prtitle)


### PR DESCRIPTION
Changes have been made in scripts/writeToFile.py and Jenkinsfile.
This script and Jenkinsfile are to use with one configuration.
Two directories are created : PR# and PR#/PR#config1. Pictures with histograms are copied to PR#/PR#config1. The txt file containing the information to be written on the web page is in the file PR#/validation_webpages.txt

PR#/
PR#/validation_webpages.txt
PR#/PR#config1

 
