### PR TITLE
Update global tag

### DIFF
--- a/scripts/produceData.sh
+++ b/scripts/produceData.sh
@@ -15,7 +15,7 @@ if [[ -n $2 ]] #if not empty
 then
   cmsDriver.py hgcal_tpg_validation -n 50 + \
   --mc --eventcontent FEVTDEBUG --datatier GEN-SIM-DIGI-RAW + \
-  --conditions auto:phase2_realistic + \
+  --conditions auto:phase2_realistic_T15 + \
   --beamspot HLLHC14TeV + \
   --step USER:Validation/HGCalValidation/hgcalRunEmulatorValidationTPG_cff.hgcalTPGRunEmulatorValidation + \
   --geometry Extended2026D49 --era Phase2C9 --procModifiers $2 + \
@@ -26,7 +26,7 @@ then
 else
   cmsDriver.py hgcal_tpg_validation -n 50 + \
   --mc --eventcontent FEVTDEBUG --datatier GEN-SIM-DIGI-RAW + \
-  --conditions auto:phase2_realistic + \
+  --conditions auto:phase2_realistic_T15 + \
   --beamspot HLLHC14TeV + \
   --step USER:Validation/HGCalValidation/hgcalRunEmulatorValidationTPG_cff.hgcalTPGRunEmulatorValidation + \
   --geometry Extended2026D49 --era Phase2C9 + \


### PR DESCRIPTION
- Update global tag to `phase2_realistic_T15`
- Fixes warning message when using `phase2_realistic`
```
The key phase2_realistic now points to 124X_mcRun4_realistic_v2.
 Usage of this key is discretionary and users are cautioned to use it at their own risk!
 This Global Tag contains tags suited for an Inner Tracker layout with rectangular (25x100um2) pixel cells (T15,T21).
```