### PR TITLE
Fix dropped products in input commands

### DIFF
--- a/scripts/produceData.sh
+++ b/scripts/produceData.sh
@@ -19,7 +19,7 @@ then
   --beamspot HLLHC14TeV + \
   --step USER:Validation/HGCalValidation/hgcalRunEmulatorValidationTPG_cff.hgcalTPGRunEmulatorValidation + \
   --geometry Extended2026D49 --era Phase2C9 --procModifiers $2 + \
-  --inputCommands "keep *","drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT","drop l1tEMTFHit2016Extras_simEmtfDigis_RPC_HLT","drop l1tEMTFHit2016s_simEmtfDigis__HLT","drop l1tEMTFTrack2016Extras_simEmtfDigis__HLT","drop l1tEMTFTrack2016s_simEmtfDigis__HLT" + \
+  --inputCommands "keep *","drop l1tTkPrimaryVertexs_L1TkPrimaryVertex__RECO" + \
   --filein file:/data_CMS_upgrade/data_jenkins/Phase2HLTTDRSummer20ReRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/FEVT/PU200_111X_mcRun4_realistic_T15_v1-v2/003ACFBC-23B2-EA45-9A12-BECFF07760FC.root + \
   --no_output + \
   --customise_commands "process.MessageLogger.files.out_$1 = dict(); process.Timing = cms.Service('Timing', summaryOnly = cms.untracked.bool(False), useJobReport = cms.untracked.bool(True)); process.SimpleMemoryCheck = cms.Service('SimpleMemoryCheck', ignoreTotal = cms.untracked.int32(1)); process.schedule = cms.Schedule(process.user_step)"
@@ -30,7 +30,7 @@ else
   --beamspot HLLHC14TeV + \
   --step USER:Validation/HGCalValidation/hgcalRunEmulatorValidationTPG_cff.hgcalTPGRunEmulatorValidation + \
   --geometry Extended2026D49 --era Phase2C9 + \
-  --inputCommands "keep *","drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT","drop l1tEMTFHit2016Extras_simEmtfDigis_RPC_HLT","drop l1tEMTFHit2016s_simEmtfDigis__HLT","drop l1tEMTFTrack2016Extras_simEmtfDigis__HLT","drop l1tEMTFTrack2016s_simEmtfDigis__HLT" + \
+  --inputCommands "keep *","drop l1tTkPrimaryVertexs_L1TkPrimaryVertex__RECO" + \
   --filein file:/data_CMS_upgrade/data_jenkins/Phase2HLTTDRSummer20ReRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/FEVT/PU200_111X_mcRun4_realistic_T15_v1-v2/003ACFBC-23B2-EA45-9A12-BECFF07760FC.root + \
   --no_output + \
   --customise_commands "process.MessageLogger.files.out_$1 = dict(); process.Timing = cms.Service('Timing', summaryOnly = cms.untracked.bool(False), useJobReport = cms.untracked.bool(True)); process.SimpleMemoryCheck = cms.Service('SimpleMemoryCheck', ignoreTotal = cms.untracked.int32(1)); process.schedule = cms.Schedule(process.user_step)"


### PR DESCRIPTION
Migration to 12_5_2_patch1: fix dropped input products
```
An exception of category 'DictionaryNotFound' occurred while
   [0] Constructing the EventProcessor
   [1] Calling ProductRegistry::initializeLookupTables
Exception Message:
No data dictionary found for the following classes:

  edm::Wrapper<std::vector<l1t::TkPrimaryVertex> >
  std::vector<l1t::TkPrimaryVertex>
``` 