### PR TITLE
Replace subprocess.Popen.communicate() with subprocess.run()

### DIFF
--- a/scripts/produceData_multiconfiguration.py
+++ b/scripts/produceData_multiconfiguration.py
@@ -80,8 +80,7 @@ def main(subsetconfig, release):
               else:
                 command = run_cmsDriver(config_data, release)
                 sourceCmd = ['bash', '-c', command]
-                sourceProc = subprocess.Popen(sourceCmd, stdout=logfile, stderr=logfile)
-                (out, err) = sourceProc.communicate() # wait for subprocess to finish
+                sourceProc = subprocess.run(sourceCmd, stdout=logfile, stderr=logfile, check=True, text=True)
             else:
               print("Do not run this configuration: ", key, ": ", value)
 


### PR DESCRIPTION
In the script  scripts/produceData_multiconfiguration.py replace subprocess.Popen.communicate() with subprocess.run(). This allows us to get the error directly in Jenkins log.