### PR TITLE
Switch to V16 geometry

### DIFF
--- a/config/bcstc.yaml
+++ b/config/bcstc.yaml
@@ -5,12 +5,12 @@ description: |
     Custom front-end algorithm: BestChoice in CE-E and STC in CE-H
 parameters:
     nbOfEvents: 50
-    conditions: auto:phase2_realistic_T15
-    beamspot: HLLHC14TeV
-    geometry: Extended2026D49
-    era: Phase2C9
-    inputCommands: '"keep *","drop l1tTkPrimaryVertexs_L1TkPrimaryVertex__RECO"'
+    conditions: auto:phase2_realistic_T21
+    beamspot: VtxSmearedHLLHC14TeV
+    geometry: Extended2026D88
+    era: Phase2C17I13M9
+    inputCommands: '"keep *"'
     procModifiers: empty
-    filein: file:/data_CMS_upgrade/data_jenkins/Phase2HLTTDRSummer20ReRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/FEVT/PU200_111X_mcRun4_realistic_T15_v1-v2/003ACFBC-23B2-EA45-9A12-BECFF07760FC.root
+    filein: file:/data_CMS_upgrade/data_jenkins/Phase2Fall22DRMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_125X_mcRun4_realistic_v2_ext1-v1/000c5e5f-78f7-44ee-95fe-7b2f2c2e2312.root
     customise: L1Trigger/L1THGCal/customTriggerCellSelect.custom_triggercellselect_mixedBestChoiceSuperTriggerCell_decentralized
     customise_commands: ''

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -5,12 +5,12 @@ description: |
     Default TPG configuration, without any customization
 parameters:
     nbOfEvents: 50
-    conditions: auto:phase2_realistic_T15
-    beamspot: HLLHC14TeV
-    geometry: Extended2026D49
-    era: Phase2C9
-    inputCommands: '"keep *","drop l1tTkPrimaryVertexs_L1TkPrimaryVertex__RECO"'
+    conditions: auto:phase2_realistic_T21
+    beamspot: VtxSmearedHLLHC14TeV
+    geometry: Extended2026D88
+    era: Phase2C17I13M9
+    inputCommands: '"keep *"'
     procModifiers: empty
-    filein: file:/data_CMS_upgrade/data_jenkins/Phase2HLTTDRSummer20ReRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/FEVT/PU200_111X_mcRun4_realistic_T15_v1-v2/003ACFBC-23B2-EA45-9A12-BECFF07760FC.root
+    filein: file:/data_CMS_upgrade/data_jenkins/Phase2Fall22DRMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_125X_mcRun4_realistic_v2_ext1-v1/000c5e5f-78f7-44ee-95fe-7b2f2c2e2312.root
     customise: empty
     customise_commands: ''


### PR DESCRIPTION
Update config files (`default` and `bcstc`) to run the validation on V16 samples.