### PR TITLE
Add optional parameters in configuration schema

### DIFF
--- a/config/bcstc.yaml
+++ b/config/bcstc.yaml
@@ -10,7 +10,6 @@ parameters:
     geometry: Extended2026D88
     era: Phase2C17I13M9
     inputCommands: '"keep *"'
-    procModifiers: empty
     filein: file:/data_CMS_upgrade/data_jenkins/Phase2Fall22DRMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_125X_mcRun4_realistic_v2_ext1-v1/000c5e5f-78f7-44ee-95fe-7b2f2c2e2312.root
     customise: L1Trigger/L1THGCal/customTriggerCellSelect.custom_triggercellselect_mixedBestChoiceSuperTriggerCell_decentralized
-    customise_commands: ''
+

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -10,7 +10,5 @@ parameters:
     geometry: Extended2026D88
     era: Phase2C17I13M9
     inputCommands: '"keep *"'
-    procModifiers: empty
     filein: file:/data_CMS_upgrade/data_jenkins/Phase2Fall22DRMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_125X_mcRun4_realistic_v2_ext1-v1/000c5e5f-78f7-44ee-95fe-7b2f2c2e2312.root
-    customise: empty
-    customise_commands: ''
+

--- a/config/newProcessors.yaml
+++ b/config/newProcessors.yaml
@@ -10,7 +10,6 @@ parameters:
     geometry: Extended2026D49
     era: Phase2C9
     inputCommands: '"keep *","drop l1tTkPrimaryVertexs_L1TkPrimaryVertex__RECO"'
-    procModifiers: empty
     filein: file:/data_CMS_upgrade/data_jenkins/Phase2HLTTDRSummer20ReRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/FEVT/PU200_111X_mcRun4_realistic_T15_v1-v2/003ACFBC-23B2-EA45-9A12-BECFF07760FC.root
     customise: L1Trigger/L1THGCal/customNewProcessors.custom_clustering_standalone,L1Trigger/L1THGCal/customNewProcessors.custom_tower_standalone,L1Trigger/L1THGCalUtilities/customNtuples.custom_ntuples_standalone_clustering,L1Trigger/L1THGCalUtilities/customNtuples.custom_ntuples_standalone_tower
-    customise_commands: ''
+

--- a/config/s1fw.yaml
+++ b/config/s1fw.yaml
@@ -10,7 +10,6 @@ parameters:
     geometry: Extended2026D88
     era: Phase2C17I13M9
     inputCommands: '"keep *"'
-    procModifiers: empty
     filein: file:/data_CMS_upgrade/data_jenkins/Phase2Fall22DRMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_125X_mcRun4_realistic_v2_ext1-v1/000c5e5f-78f7-44ee-95fe-7b2f2c2e2312.root
     customise: L1Trigger/L1THGCal/customLayer1.custom_layer1_latestfw
     customise_commands: "process.L1THGCalTrigPrimValidation.Clusters = process.l1tHGCalBackEndLayer2Producer.InputCluster;"

--- a/scripts/configFunctions.py
+++ b/scripts/configFunctions.py
@@ -65,11 +65,13 @@ def check_schema_paramValJob(config, filename):
     })
 
     try:
-      config_schema.validate(config)
+      validated_config_schema = config_schema.validate(config)
     except SchemaError as se:
       print(f"\n\n === The configuration format is not correct. Please check the file {filename}. === \n\n {se}")
       raise Exception(f"\n\n === The configuration format is not correct. Please check the file {filename}. === \n\n {se}")
- 
+    
+    return validated_config_schema
+    
 # Read the file with configurations sets
 def read_subset(path, config):
     filename = path + config + '.yaml'

--- a/scripts/configFunctions.py
+++ b/scripts/configFunctions.py
@@ -18,11 +18,13 @@ def check_schema_subset(config, filename):
     })
 
     try:
-      config_schema.validate(config)
+      validated_config_schema = config_schema.validate(config)
     except SchemaError as se:
       print(f"\n\n === The configuration format is not correct. Please check the file {filename}. === \n\n {se}")
       raise Exception(f"\n\n === The configuration format is not correct. Please check the file {filename}. === \n\n {se}")
-      
+
+    return validated_config_schema
+    
 # Define the schema of the configuration data
 def check_schema_config(config, filename):
     config_schema = Schema({
@@ -44,11 +46,13 @@ def check_schema_config(config, filename):
     })
 
     try:
-        config_schema.validate(config)
+        validated_config_schema = config_schema.validate(config)
     except SchemaError as se:
         print(f"\n\n === The configuration format is not correct. Please check the file {filename}. === \n\n {se}")
         raise Exception(f"\n\n The configuration format is not correct. Please check the file {filename}. === \n\n {se}")
-
+    
+    return validated_config_schema
+    
 # Define the schema of the config for the Jenkins job
 # validating the validation code
 def check_schema_paramValJob(config, filename):
@@ -80,9 +84,9 @@ def read_subset(path, config):
         print(f"\n\n === Error parsing YAML file: {filename} === \n\n {e}")
         raise Exception(f"\n\n === Error parsing YAML file: {filename}. === \n\n{e}")
 
-    check_schema_subset(subset, filename)
+    validated_subset = check_schema_subset(subset, filename)
 
-    return subset
+    return validated_subset
 
 
 # Return a list with config pairs (ref, test)
@@ -123,10 +127,10 @@ def read_config(path, configuration, config_type):
         raise Exception(f"\n\n === Error parsing configuration YAML file: {filename}. === \n\n {e}")
     
     if (config_type == 1):
-        check_schema_config(config, filename)
+        validated_config = check_schema_config(config, filename)
     elif (config_type == 2):
-        check_schema_paramValJob(config, filename)
+        validated_config = check_schema_paramValJob(config, filename)
     else:
         print(f"\n\n === The config_type doesn't correspond to the defined validation types. === \n\n")
 
-    return config
+    return validated_config

--- a/scripts/configFunctions.py
+++ b/scripts/configFunctions.py
@@ -38,10 +38,10 @@ def check_schema_config(config, filename):
             "geometry": str,
             "era": str,
             "inputCommands": str,
-            "procModifiers": str,
+            Optional("procModifiers", default='empty'): str,
             "filein": str,
-            "customise": str,
-            "customise_commands": str
+            Optional("customise", default="empty"): str,
+            Optional("customise_commands", default=''): str
         }
     })
 

--- a/scripts/configFunctions.py
+++ b/scripts/configFunctions.py
@@ -6,7 +6,7 @@ import os
 import sys
 import subprocess
 
-from schema import Schema, SchemaError
+from schema import Schema, Optional, SchemaError
 
 # Define the schema of the subset config file
 def check_schema_subset(config, filename):


### PR DESCRIPTION
- Make three parameters optional in configuration schema:
procModifiers
customise
customise_commands

- Update configFunctions.py script in order to give default values to optional parameters

- Remove optional parameters from default configuration