### PR TITLE
New way to retrieve Jenkins job name 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,10 +27,10 @@ pipeline {
                 '''
                 script{
                     String s = env.JOB_NAME
-                    s = s.substring(s.indexOf("/") + 1)
-                    s = s.substring(0, s.indexOf("/"));
-                    println(s);
-                    switch(s){
+                    String[] elements = s.split("/")
+                    String job_name = elements[-2]
+                    println(job_name);
+                    switch(job_name){
                        case 'HGC TPG CMSSW Validation':
                             env.EMAIL_TO=env.HGCTPG_EMAIL_TO_MAIN
                             env.BASE_REMOTE=env.HGCTPG_BASE_REMOTE_MAIN


### PR DESCRIPTION
Change the way to retrieve jobs name from the Jenkins environment variable JOB_NAME. This allows to use Jenkins job from folders.