### PR TITLE
Testing  leak memory in produce step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,7 +262,7 @@ pipeline {
                         echo 'LABEL_TEST = ' ${LABEL_TEST}
                         echo 'SCRAM_ARCH = ' ${SCRAM_ARCH}
                         python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_TEST} &
-                        get_rss_memory.sh $! 10
+                        ../../../HGCTPGValidation/scripts/get_rss_memory.sh $! 10
                         echo '      '
                         '''
                     }
@@ -302,7 +302,7 @@ pipeline {
                         python --version
                         echo ' CONFIG_SUBSET = ' ${CONFIG_SUBSET}
                         python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_REF} &
-                        get_rss_memory.sh $! 10
+                        ../../../HGCTPGValidation/scripts/get_rss_memory.sh $! 10
                         echo '      '
                         '''
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,7 +262,6 @@ pipeline {
                         echo 'LABEL_TEST = ' ${LABEL_TEST}
                         echo 'SCRAM_ARCH = ' ${SCRAM_ARCH}
                         python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_TEST} &
-                        ../../../HGCTPGValidation/scripts/get_rss_memory.sh $! 10
                         echo '      '
                         '''
                     }
@@ -302,7 +301,6 @@ pipeline {
                         python --version
                         echo ' CONFIG_SUBSET = ' ${CONFIG_SUBSET}
                         python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_REF} &
-                        ../../../HGCTPGValidation/scripts/get_rss_memory.sh $! 10
                         echo '      '
                         '''
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,7 +261,8 @@ pipeline {
                         echo ' CONFIG_SUBSET = ' ${CONFIG_SUBSET}
                         echo 'LABEL_TEST = ' ${LABEL_TEST}
                         echo 'SCRAM_ARCH = ' ${SCRAM_ARCH}
-                        python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_TEST}
+                        python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_TEST} &
+                        get_rss_memory.sh $! 10
                         echo '      '
                         '''
                     }
@@ -300,7 +301,8 @@ pipeline {
                         module load python/3.9.9
                         python --version
                         echo ' CONFIG_SUBSET = ' ${CONFIG_SUBSET}
-                        python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_REF}
+                        python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_REF} &
+                        get_rss_memory.sh $! 10
                         echo '      '
                         '''
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,7 +261,7 @@ pipeline {
                         echo ' CONFIG_SUBSET = ' ${CONFIG_SUBSET}
                         echo 'LABEL_TEST = ' ${LABEL_TEST}
                         echo 'SCRAM_ARCH = ' ${SCRAM_ARCH}
-                        python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_TEST} &
+                        python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_TEST}
                         echo '      '
                         '''
                     }
@@ -300,7 +300,7 @@ pipeline {
                         module load python/3.9.9
                         python --version
                         echo ' CONFIG_SUBSET = ' ${CONFIG_SUBSET}
-                        python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_REF} &
+                        python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_REF}
                         echo '      '
                         '''
                     }

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -30,7 +30,7 @@ while true; do
         if [ -e /proc/$PID/status ]; then
             echo "Free memory (RSS) for process $1 (PID: $PID): ${RSS} kB"
         else
-            echo "ProduceData_multiconfiguration.py process finished."
+            echo "ProduceData_multiconfiguration.py process finished. PID = $PID"
             break;
         fi
     fi

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Usage: call the script in Jenkinsfile immediately after 
+# python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_REF}
+# get_rss_memory.sh $! interval
+# 1rst argument: "$!" is the PID of python produceData_multiconfiguration.py process
+# 2nd argument: interval in seconds
+
+# Check if process name is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 PID"
+    exit 1
+fi
+
+# Get the PID of the process
+PID=$1
+echo $PID
+INTERVAL=$2
+
+while true; do
+    PID=$1
+    
+    if [ -z "$PID" ]; then
+        echo "Process $PID not found."
+    else
+        # Get the RSS (Resident Set Size) memory usage
+        RSS=$(grep -i vmrss /proc/$PID/status | awk '{print $2}')
+        
+        # Output the RSS memory usage
+        if [ -e /proc/$PID/status ]; then
+            echo "Free memory (RSS) for process $1 (PID: $PID): ${RSS} kB"
+        else
+            echo "ProduceData_multiconfiguration.py process finished."
+            break;
+        fi
+    fi
+    
+    sleep $INTERVAL
+done

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -6,9 +6,21 @@
 # 2nd argument: interval in seconds
 # 3th argument: memory limit
 
-# Check if process name is provided
+# Check if the PID of the last process is provided
 if [ -z "$1" ]; then
-    echo "Usage: $0 PID"
+    echo "Usage: $0 PID INTERVALL RSS_LIMIT"
+    exit 1
+fi
+
+# Check if the limit RSS is provided
+if [ -z "$2" ]; then
+    echo "Usage: $0 PID INTERVALL RSS_LIMIT"
+    exit 1
+fi
+
+# Check if the Interval (in s) is provided
+if [ -z "$3" ]; then
+    echo "Usage: $0 PID INTERVALL RSS_LIMIT"
     exit 1
 fi
 
@@ -16,32 +28,34 @@ fi
 INTERVAL=$2
 RSS_limit=$3
 
+sleep 20
+    
 while true; do
     echo "LastProcess PID= " $1
+    
+    ps
+    
+    # Get PID for the process "cmsRun" and the user "jenkins"
     p_all=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print}')
-    echo $p_all
+    echo "=== > Information about the process (PID user name_process): " $p_all
+    
     PID=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print $1}')
     echo "PID=" $PID
     
-    if [ -z "$PID" ]; then
+    if [ -z "$PID" ] || [ ! -e /proc/$PID/status ] ; then
         echo "Process $PID not found."
+        break;
     else
         # Get the RSS (Resident Set Size) memory usage
-        echo "Get RSS value "
         RSS=$(grep -i vmrss /proc/$PID/status | awk '{print $2}')
+        echo "Free memory (RSS) for process PID=$PID: ${RSS} kB"
+        
         if [ "${RSS}" -gt "${RSS_limit}" ]; then
             kill -9 $PID;
             echo "===> RSS memory ${RSS} > RSS limit ${RSS_limit}";
             break;
         fi
         
-        # Output the RSS memory usage
-        if [ -e /proc/$PID/status ]; then
-            echo "Free memory (RSS) for process $1 (PID: $PID): ${RSS} kB"
-        else
-            echo "ProduceData_multiconfiguration.py process finished. PID = $PID"
-            break;
-        fi
     fi
     
     sleep $INTERVAL

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -27,11 +27,8 @@ while true; do
         echo "Process $PID not found."
     else
         # Get the RSS (Resident Set Size) memory usage
-        cp /proc/$PID/status ./status_${PID}
-        ps
         echo "Get RSS value "
         RSS=$(grep -i vmrss /proc/$PID/status | awk '{print $2}')
-        echo "===> RSS memory ${RSS}"
         if [ "${RSS}" -gt "${RSS_limit}" ]; then
             kill -9 $PID;
             echo "===> RSS memory ${RSS} > RSS limit ${RSS_limit}";

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# Usage: call the script in Jenkinsfile immediately after 
-# python ../../../HGCTPGValidation/scripts/produceData_multiconfiguration.py --subsetconfig ${CONFIG_SUBSET} --label ${LABEL_REF}
-# get_rss_memory.sh $! interval
+# Usage: call the script in HGCTPGValidation/scripts/produceData_multiconfiguration.py immediately after cmsRun
+# get_rss_memory.sh $! interval limit
 # 1rst argument: "$!" is the PID of python produceData_multiconfiguration.py process
 # 2nd argument: interval in seconds
+# 3th argument: memory limit
 
 # Check if process name is provided
 if [ -z "$1" ]; then
@@ -13,18 +13,30 @@ if [ -z "$1" ]; then
 fi
 
 # Get the PID of the process
-PID=$1
-echo $PID
 INTERVAL=$2
+RSS_limit=$3
 
 while true; do
-    PID=$1
+    echo "LastProcess PID= " $1
+    p_all=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print}')
+    echo $p_all
+    PID=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print $1}')
+    echo "PID=" $PID
     
     if [ -z "$PID" ]; then
         echo "Process $PID not found."
     else
         # Get the RSS (Resident Set Size) memory usage
+        cp /proc/$PID/status ./status_${PID}
+        ps
+        echo "Get RSS value "
         RSS=$(grep -i vmrss /proc/$PID/status | awk '{print $2}')
+        echo "===> RSS memory ${RSS}"
+        if [ "${RSS}" -gt "${RSS_limit}" ]; then
+            kill -9 $PID;
+            echo "===> RSS memory ${RSS} > RSS limit ${RSS_limit}";
+            break;
+        fi
         
         # Output the RSS memory usage
         if [ -e /proc/$PID/status ]; then

--- a/scripts/produceData_multiconfiguration.py
+++ b/scripts/produceData_multiconfiguration.py
@@ -47,7 +47,7 @@ def run_cmsDriver(configdata, release):
     --filein {filein} \
     --no_output \
     {customise} \
-    --customise_commands {customiseCommand}"
+    --customise_commands {customiseCommand} & ../../../HGCTPGValidation/scripts/get_rss_memory.sh $! 10"
     
     pprint.pprint(command)
     return command

--- a/scripts/produceData_multiconfiguration.py
+++ b/scripts/produceData_multiconfiguration.py
@@ -47,7 +47,7 @@ def run_cmsDriver(configdata, release):
     --filein {filein} \
     --no_output \
     {customise} \
-    --customise_commands {customiseCommand} & ../../../HGCTPGValidation/scripts/get_rss_memory.sh $! 10"
+    --customise_commands {customiseCommand} & ../../../HGCTPGValidation/scripts/get_rss_memory.sh $! 10 10000000"
     
     pprint.pprint(command)
     return command


### PR DESCRIPTION
- Add new script scripts/get_rss_memory.sh for checking the RSS memory usage
- The script is called during the Produce step in the python produceData_multiconfiguration.py 
- The script takes three arguments, the PID of the process, and the interval (in s) and the memory limit (kB)