### PR TITLE
Improve the script for rss memory check

### DIFF
--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -46,7 +46,7 @@ while true; do
        sleep 10
        echo "Waiting for the process cmsRun to be run."
        ((i++))
-    elif [ $i -eq $limit_time ] ; then
+    elif [ -z "$PID" ] && [ $i -ge $limit_time ] ; then
         echo "WARNING: The PID for the process cmsRun has not been found." 1>&2 &&
         break;
     else

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -44,6 +44,7 @@ while true; do
     # Get the PID for the process "cmsRun" and the use "jenkins" and corresponding to $PID_process
     PID=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | grep $PID_process | awk '{print $1}')
     
+    # Waiting for the PID process to be run until the limit time is over
     if [ -z "$PID" ] && [ $i -lt $limit_time ] ; then
        sleep 10
        echo "Waiting for the process cmsRun to be run."
@@ -52,6 +53,8 @@ while true; do
         echo "WARNING: The PID for the process cmsRun has not been found." 1>&2 &&
         exit 0;
     else
+        # The PID process has been found
+        
         # Prints the pid, user name and the command name
         # We select the process "cmsRun" and the use "jenkins"
         p_all=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | grep $PID_process | awk '{print}')
@@ -60,10 +63,12 @@ while true; do
         # Prints the number of cmsRun processes corresponding to the user "jenkins"
         p_all_nb=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | grep $PID_process | awk 'END {print NR}')
         echo "The number of the cmsRun processes is " $p_all_nb
+        
         break;
     fi
 done
 
+# Starts monitoring the RSS memory of the process
 while true; do
     
     if [ ! -e /proc/$PID/status ] ; then

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -40,7 +40,7 @@ echo "STARTS get_rss_memory"
 i=0
 limit_time=120 # in seconds
 while true; do
-    
+    ps
     # Get the PID for the process "cmsRun" and the use "jenkins" and corresponding to $PID_process
     PID=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | grep $PID_process | awk '{print $1}')
     

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -41,8 +41,8 @@ i=0
 limit_time=120 # in seconds
 while true; do
     
-    # Get the PID for the process "cmsRun" and the use "jenkins"
-    PID=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print $1}')
+    # Get the PID for the process "cmsRun" and the use "jenkins" and corresponding to $PID_process
+    PID=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | grep $PID_process | awk '{print $1}')
     
     if [ -z "$PID" ] && [ $i -lt $limit_time ] ; then
        sleep 10
@@ -54,11 +54,11 @@ while true; do
     else
         # Prints the pid, user name and the command name
         # We select the process "cmsRun" and the use "jenkins"
-        p_all=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print}')
+        p_all=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | grep $PID_process | awk '{print}')
         echo "=== > Information about the process (PID user name_process): " $p_all
         
         # Prints the number of cmsRun processes corresponding to the user "jenkins"
-        p_all_nb=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk 'END {print NR}')
+        p_all_nb=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | grep $PID_process | awk 'END {print NR}')
         echo "The number of the cmsRun processes is " $p_all_nb
         break;
     fi

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -29,6 +29,7 @@ if [ -z "$3" ]; then
 fi
 
 # Get the PID of the process
+PID_process=$1
 INTERVAL=$2
 RSS_limit=$3
 

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -45,7 +45,7 @@ while true; do
     if [ -z "$PID" ] && [ $i -lt $limit_time ] ; then
        sleep 10
        echo "Waiting for the process cmsRun to be run."
-       ((i++))
+       i = $i + 10
     elif [ -z "$PID" ] && [ $i -ge $limit_time ] ; then
         echo "WARNING: The PID for the process cmsRun has not been found." 1>&2 &&
         exit 0;

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -48,7 +48,7 @@ while true; do
        ((i++))
     elif [ -z "$PID" ] && [ $i -ge $limit_time ] ; then
         echo "WARNING: The PID for the process cmsRun has not been found." 1>&2 &&
-        break;
+        exit 0;
     else
         p_all=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print}')
         echo "=== > Information about the process (PID user name_process): " $p_all

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -55,7 +55,10 @@ while true; do
         # We select the process "cmsRun" and the use "jenkins"
         p_all=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print}')
         echo "=== > Information about the process (PID user name_process): " $p_all
-        echo "PID=" $PID
+        
+        # Prints the number of cmsRun processes corresponding to the user "jenkins"
+        p_all_nb=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk 'END {print NR}')
+        echo "The number of the cmsRun processes is " $p_all_nb
         break;
     fi
 done

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -37,9 +37,10 @@ echo "STARTS get_rss_memory"
 # Waiting for the process cmsRun to be run
 # Max waiting time = 120s
 i=0
-limit_time=120
+limit_time=120 # in seconds
 while true; do
     
+    # Get the PID for the process "cmsRun" and the use "jenkins"
     PID=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print $1}')
     
     if [ -z "$PID" ] && [ $i -lt $limit_time ] ; then
@@ -50,13 +51,15 @@ while true; do
         echo "WARNING: The PID for the process cmsRun has not been found." 1>&2 &&
         exit 0;
     else
+        # Prints the pid, user name and the command name
+        # We select the process "cmsRun" and the use "jenkins"
         p_all=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print}')
         echo "=== > Information about the process (PID user name_process): " $p_all
         echo "PID=" $PID
         break;
     fi
 done
- 
+
 while true; do
     
     if [ ! -e /proc/$PID/status ] ; then

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -48,7 +48,7 @@ while true; do
     if [ -z "$PID" ] && [ $i -lt $limit_time ] ; then
        sleep 10
        echo "Waiting for the process cmsRun to be run."
-       i = $i + 10
+       i=$((i+10))
     elif [ -z "$PID" ] && [ $i -ge $limit_time ] ; then
         echo "WARNING: The PID for the process cmsRun has not been found." 1>&2 &&
         exit 0;

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -12,19 +12,19 @@ DEBUG=1
 
 # Check if the PID of the last process is provided
 if [ -z "$1" ]; then
-    echo "Usage: $0 PID INTERVAL RSS_LIMIT"
+    echo "ERROR Usage: $0 PID INTERVAL RSS_LIMIT" 1>&2 &&
     exit 1
 fi
 
 # Check if the Interval (in s) is provided
 if [ -z "$2" ]; then
-    echo "Usage: $0 PID INTERVAL RSS_LIMIT"
+    echo "ERROR Usage: $0 PID INTERVAL RSS_LIMIT" 1>&2 &&
     exit 1
 fi
 
 # Check if the limit RSS is provided
 if [ -z "$3" ]; then
-    echo "Usage: $0 PID INTERVAL RSS_LIMIT"
+    echo "ERROR Usage: $0 PID INTERVAL RSS_LIMIT" 1>&2 &&
     exit 1
 fi
 
@@ -64,7 +64,7 @@ while true; do
         fi
         
         if [ "${RSS}" -gt "${RSS_limit}" ]; then
-            echo "===> RSS memory $(( ${RSS} / 1000 )) MB > RSS limit $(( ${RSS_limit} / 1000 )) MB"  1>&2 &&
+            echo "ERROR: RSS memory $(( ${RSS} / 1000 )) MB > RSS limit $(( ${RSS_limit} / 1000 )) MB"  1>&2 &&
             kill -9 $PID &&
             exit 1;
         fi  

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -35,9 +35,9 @@ RSS_limit=$3
 echo "STARTS get_rss_memory"
 
 # Waiting for the process cmsRun to be run
-# Max waiting time = 300s
+# Max waiting time = 120s
 i=0
-limit_time=300
+limit_time=120
 while true; do
     
     PID=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print $1}')

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -47,8 +47,8 @@ while true; do
        echo "Waiting for the process cmsRun to be run."
        ((i++))
     elif [ $i -eq $limit_time ] ; then
-        echo "ERROR: The PID for the process cmsRun has not been found." 1>&2 &&
-        exit 1;
+        echo "WARNING: The PID for the process cmsRun has not been found." 1>&2 &&
+        break;
     else
         p_all=$(ps -eo pid,user,comm | grep cmsRun | grep jenkins | awk '{print}')
         echo "=== > Information about the process (PID user name_process): " $p_all

--- a/scripts/produceData_multiconfiguration.py
+++ b/scripts/produceData_multiconfiguration.py
@@ -51,7 +51,7 @@ def run_cmsDriver(configdata, release):
     --filein {filein} \
     --no_output \
     {customise} \
-    --customise_commands {customiseCommand}"
+    --customise_commands {customiseCommand} & ../../../HGCTPGValidation/scripts/get_rss_memory.sh $! {INTERVAL} {RSS_limit}"
     
     pprint.pprint(command)
     return command


### PR DESCRIPTION
The main improvement is related to retrieval of the process PID:
- The script wait until the process is run 
- To avoid infinite loop, a max waiting time is set

Additional impprovements:
- Redirect stdout to strderr when there is an exit, this will allow to see the error message in GitHub and in Jenkins consol output
- The error messages are identified with an explicitly