### PR TITLE
Jenkins: fix the search of rss memory

### DIFF
--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -8,8 +8,6 @@
 # 2nd argument: interval in seconds
 # 3th argument: memory limit
 
-DEBUG=1
-
 # Check if the PID of the last process is provided
 if [ -z "$1" ]; then
     echo "ERROR Usage: $0 PID INTERVAL RSS_LIMIT" 1>&2 &&
@@ -77,9 +75,6 @@ while true; do
     else
         # Get the RSS (Resident Set Size) memory usage
         RSS=$(grep -i vmrss /proc/$PID/status | awk '{print $2}')
-        if [ "$DEBUG" = "1" ] ; then
-            echo "Free memory (RSS) for process PID=$PID: $(( ${RSS} / 1000 )) MB"
-        fi
         
         if [ "${RSS}" -gt "${RSS_limit}" ]; then
             echo "ERROR: RSS memory $(( ${RSS} / 1000 )) MB > RSS limit $(( ${RSS_limit} / 1000 )) MB"  1>&2 &&

--- a/scripts/get_rss_memory.sh
+++ b/scripts/get_rss_memory.sh
@@ -76,11 +76,16 @@ while true; do
         # Get the RSS (Resident Set Size) memory usage
         RSS=$(grep -i vmrss /proc/$PID/status | awk '{print $2}')
         
-        if [ "${RSS}" -gt "${RSS_limit}" ]; then
+        if [ -z "${RSS}" ] ; then
+            echo "WARNING: The RSS memory has not been found." 1>&2 &&
+            break;
+        elif [ -n "${RSS}" ] && [ "${RSS}" -gt "${RSS_limit}" ] ; then
             echo "ERROR: RSS memory $(( ${RSS} / 1000 )) MB > RSS limit $(( ${RSS_limit} / 1000 )) MB"  1>&2 &&
             kill -9 $PID &&
             exit 1;
-        fi  
+        else
+            echo "Free memory (RSS) for process PID=$PID: $(( ${RSS} / 1000 )) MB"
+        fi
     fi    
     sleep $INTERVAL
 done


### PR DESCRIPTION
- In the script get_rss_memory.sh, we added a condition to check if the RSS value for a given process was found. If it was not found, the process stops monitoring the RSS memory of this process.
- Tested with the release CMSSW_14_0_0_pre1