### PR TITLE
Add ROOT file as an artefact

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -285,7 +285,7 @@ pipeline {
                     try{
                         sh'./HGCTPGValidation/scripts/geom_check.sh ${TEST_RELEASE} ${LABEL_TEST}'
                     } catch (e){
-                        echo "An error occured in Geom testing stage: ${e}"
+                        error("An error occured in Geom testing stage: ${e}")
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -315,7 +315,7 @@ pipeline {
                     '''
                 }
             }
-            archiveArtifacts artifacts: 'log_Jenkins', fingerprint: true
+            archiveArtifacts artifacts: 'log_Jenkins, test_dir/**/src/test_triggergeom.root'', fingerprint: true
         }
         success {
             echo 'The job finished successfully.'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -315,7 +315,7 @@ pipeline {
                     '''
                 }
             }
-            archiveArtifacts artifacts: 'log_Jenkins, test_dir/**/src/test_triggergeom.root'', fingerprint: true
+            archiveArtifacts artifacts: 'log_Jenkins, test_dir/**/src/test_triggergeom.root', fingerprint: true
         }
         success {
             echo 'The job finished successfully.'

--- a/scripts/geom_check.sh
+++ b/scripts/geom_check.sh
@@ -17,4 +17,11 @@ cd test_dir/${TEST_RELEASE}_HGCalTPGValidation_${LABEL_TEST}/src
 source /cvmfs/cms.cern.ch/cmsset_default.sh; 
 eval `scramv1 runtime -sh`;
 cmsRun L1Trigger/L1THGCal/test/testHGCalL1TGeometryV16_cfg.py
-
+if [ -f test_dir/${TEST_RELEASE}_HGCalTPGValidation_${LABEL_TEST}/src/test_triggergeom.root ]; 
+then
+    echo "The ROOT file test_triggergeom.root was created successfully."
+else
+    echo "The ROOT file was not created."
+    exit 1;
+fi
+echo '    '

--- a/scripts/geom_check.sh
+++ b/scripts/geom_check.sh
@@ -17,7 +17,7 @@ cd test_dir/${TEST_RELEASE}_HGCalTPGValidation_${LABEL_TEST}/src
 source /cvmfs/cms.cern.ch/cmsset_default.sh; 
 eval `scramv1 runtime -sh`;
 cmsRun L1Trigger/L1THGCal/test/testHGCalL1TGeometryV16_cfg.py
-if [ -f test_dir/${TEST_RELEASE}_HGCalTPGValidation_${LABEL_TEST}/src/test_triggergeom.root ]; 
+if [ -f test_triggergeom.root ]; 
 then
     echo "The ROOT file test_triggergeom.root was created successfully."
 else


### PR DESCRIPTION
- Add ROOT file created in the stage "Geom Check" as artefact
- In the geom_check.sh script Check if the ROOT file was created
- In the Geom check stage, signals an error and stops the build
Tested with the release CMSSW_14_0_0_pre1.