### PR TITLE
Keep artefacts for limited time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,8 @@ pipeline {
         CONFIG_SUBSET = 'default_multi_subset'
     }
     options {
-        skipDefaultCheckout() 
+        skipDefaultCheckout()
+        buildDiscarder logRotator(artifactDaysToKeepStr: '7', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '')
     }
     stages {
         stage('Set environment variables'){


### PR DESCRIPTION
Add a buildDiscarder option for keeping artefacts only for 7 days.
With the PR 53 we added a ROOT file as artefact. In order to avoir disque space saturation we keep it only for limited time. 